### PR TITLE
fix: accessibility improvements

### DIFF
--- a/src/app/(home)/components/Section1.tsx
+++ b/src/app/(home)/components/Section1.tsx
@@ -17,7 +17,8 @@ export default function Section1() {
         <Image
           priority={false}
           loading="lazy"
-          alt="CeZPEM"
+          alt="" 
+          aria-hidden="true"
           src="/details-1-top-right.png"
           className="absolute -top-8 -right-[1px]"
           width={249}
@@ -27,7 +28,8 @@ export default function Section1() {
         <Image
           priority={false}
           loading="lazy"
-          alt="CeZPEM"
+          alt="" 
+          aria-hidden="true"
           src="/details-1-bottom-left.png"
           className="absolute -bottom-[1px] -left-[1px]"
           width={249}
@@ -39,12 +41,14 @@ export default function Section1() {
         <div className="w-full text-white text-center flex flex-col items-center justify-center gap-2 px-4 sm:px-0">
           <h1 className="text-40px sm:text-64px font-bold">
             Conheça o{" "}
+            <span className="sr-only">CeZPEM.</span>
             <span className="sm:-ml-2 h-7 md:h-16 w-[150px] sm:w-[249px] inline-block">
               <span className="relative flex w-auto h-auto sm:h-[24px] md:h-[94px] mt-4 sm:mt-0">
                 <Image
                   priority
                   loading="eager"
-                  alt="Logo do CeZPEM"
+                  alt="" 
+                  aria-hidden="true"
                   src="/CeZPEM.svg"
                   className="absolute z-[1] top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-auto h-auto"
                   width={249 * 2}
@@ -52,15 +56,19 @@ export default function Section1() {
                 />
 
                 <span className="absolute z-[0] top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-[180px] h-[74px] sm:w-[264px] sm:h-[98px]">
-                  <Lottie animationData={highlightAnimation} loop={false} />
+                  <Lottie aria-hidden="true" animationData={highlightAnimation} loop={false} />
                 </span>
               </span>
             </span>
           </h1>
 
           <div className="font-archivo mx-auto max-w-[700px] text-20px md:text-24px">
-            O Centro <b> Zoia Prestes </b> de Educação Multidisciplinar (CeZPEM)
-            é uma frente de massas do Coletivo{" "}
+            
+            <p className="inline">
+              O Centro <b> Zoia Prestes </b> de Educação Multidisciplinar <span className="sr-only">cezpem</span><abbr aria-hidden="true">(CeZPEM)</abbr> {" "}
+              é uma frente de massas do Coletivo{" "} <span className="sr-only">Soberana.</span>
+            </p>
+            
             <span className="ml-2 h-6 w-32 inline-block">
               <span className="relative flex h-5 mt-0">
                 <SoberanaLogoText

--- a/src/app/(home)/components/Section1Players.tsx
+++ b/src/app/(home)/components/Section1Players.tsx
@@ -27,6 +27,7 @@ export default function Section1Players() {
             thumbnail="/video-cover.jpg"
             id="kRQkAR05kAI"
             title="Organize-se no CeZPEM"
+            announce="Assista ao vídeo"
             aspectHeight={9}
             aspectWidth={16}
           />

--- a/src/app/(home)/components/Section2.tsx
+++ b/src/app/(home)/components/Section2.tsx
@@ -18,7 +18,8 @@ export default function Section2() {
             <Image
               priority={false}
               loading="lazy"
-              alt="CeZPEM"
+              alt="" 
+              aria-hidden="true"
               src="/enem-cezpem.png"
               className="max-w-none absolute md:relative w-[120vw] md:w-full md:max-w-[926px] -left-8 top-4 mx-auto md:left-auto xl:left-12 md:top-0"
               width={249 * 2}
@@ -30,7 +31,8 @@ export default function Section2() {
             <Image
               priority={false}
               loading="lazy"
-              alt="CeZPEM"
+              alt="" 
+              aria-hidden="true"
               src="/CeZPEM-bottom.png"
               className="w-full md:hidden max-w-[100px] mx-auto"
               width={249}
@@ -44,7 +46,8 @@ export default function Section2() {
               <Image
                 priority={false}
                 loading="lazy"
-                alt="CeZPEM"
+                alt="" 
+                aria-hidden="true"
                 src="/details-text.png"
                 className="absolute z-0 w-auto max-w-full xs:w-full sm:max-w-[90%] sm:ml-1 md:max-w-full transform -translate-y-1/2 -translate-x-1/2 left-1/2 top-7 md:h-9 md:top-[38px] md:ml-4 lg:top-9 lg:ml-16 xl:ml-4"
                 width={484 * 2}
@@ -53,7 +56,7 @@ export default function Section2() {
             </PageTitle>
 
             <p className="w-full leading-tight font-archivo text-20px md:text-24px md:mt-6 text-center lg:text-right">
-              O cursinho Popular do <b> CeZPEM </b> oferece aulas gratuitas
+              O cursinho Popular do <span className="sr-only">cezpem</span><b aria-hidden="true"> CeZPEM </b> oferece aulas gratuitas
               voltadas aos conteúdos da grade regular do Enem.
             </p>
 

--- a/src/app/(home)/components/Section3.tsx
+++ b/src/app/(home)/components/Section3.tsx
@@ -16,7 +16,8 @@ export default function Section3() {
         <Image
           priority={false}
           loading="lazy"
-          alt="CeZPEM"
+          alt="" 
+          aria-hidden="true"
           src="/details-2-top-left.png"
           className="absolute -top-[1px] -left-[1px]"
           width={249}
@@ -26,7 +27,8 @@ export default function Section3() {
         <Image
           priority={false}
           loading="lazy"
-          alt="CeZPEM"
+          alt="" 
+          aria-hidden="true"
           src="/details-2-bottom-right.png"
           className="absolute -bottom-8 -right-[1px]"
           width={249}
@@ -38,7 +40,8 @@ export default function Section3() {
         <Image
           priority={false}
           loading="lazy"
-          alt="CeZPEM"
+          alt="" 
+          aria-hidden="true"
           src="/piggy-bank-right.png"
           className="absolute -top-1 md:-top-12 md:right-auto left-1/3 md:left-1/4 w-32 blur-[1px]"
           width={249}
@@ -48,7 +51,8 @@ export default function Section3() {
         <Image
           priority={false}
           loading="lazy"
-          alt="CeZPEM"
+          alt="" 
+          aria-hidden="true"
           src="/piggy-bank-left.png"
           className="absolute bottom-[40%] left-auto -right-5 md:-bottom-8 md:right-auto md:left-1/3 w-24 md:w-32"
           width={249}
@@ -58,10 +62,11 @@ export default function Section3() {
 
       <Container className="relative z-10 xl:min-h-[720px] grid grid-cols-1 xl:grid-cols-[36%_1fr] gap-8 md:gap-0 px-0">
         <div className="w-full h-auto my-auto flex flex-col gap-4 text-white">
-          <PageTitle className="relative text-center w-auto mx-auto mt-20 md:mt-0">
+          <PageTitle text="text-yellow" className="relative text-center w-auto mx-auto mt-20 md:mt-0">
             <span className="relative z-10">Apoie Nosso Projeto!</span>
             <Image
-              alt="CeZPEM"
+              alt="" 
+              aria-hidden="true"
               src="/details-text-2.png"
               className="absolute z-0 w-auto transform -translate-y-1/2 top-7 left-0 md:top-9 md:-right-4"
               width={484 * 2}
@@ -73,7 +78,7 @@ export default function Section3() {
             O objetivo do cursinho é garantir o acesso gratuito dos alunes à
             educação, sem deixar de remunerar os professores. Nossos recursos
             virão exclusivamente do financiamento coletivo, por isso a sua
-            colaboração é fundamental pra existência desse projeto.
+            colaboração é fundamental pra existência desse projeto. <span className="sr-only">Hoje já somos mais de 450 professores organizades, mais de 900 alunes, mais de 100 cursos ofertados e mais de 25 equipes.</span>
           </p>
 
           <div className="w-full md:my-10 ml-auto flex">
@@ -96,7 +101,8 @@ export default function Section3() {
           <Image
             priority={false}
             loading="lazy"
-            alt="CeZPEM"
+            alt="" 
+            aria-hidden="true"
             src="/piggy-bank-center.png"
             className="m-auto w-auto relative -left-8 md:-left-16 -bottom-6"
             width={484 * 2}

--- a/src/app/(home)/components/Section4.tsx
+++ b/src/app/(home)/components/Section4.tsx
@@ -13,7 +13,8 @@ export default function Section4() {
           <Image
             priority={false}
             loading="lazy"
-            alt="CeZPEM"
+            alt="" 
+            aria-hidden="true"
             src="/CeZPEM-colagem.png"
             className="w-auto m-auto"
             width={1452}
@@ -27,7 +28,8 @@ export default function Section4() {
             <Image
               priority={false}
               loading="lazy"
-              alt="CeZPEM"
+              alt="" 
+              aria-hidden="true"
               src="/details-text.png"
               className="absolute transform -translate-x-1/2 h-1/2 z-0 w-full max-w-96 md:w-full md:max-w-[440px] top-5 md:top-6 left-1/2 ml-3"
               width={484}

--- a/src/app/termos/page.tsx
+++ b/src/app/termos/page.tsx
@@ -35,7 +35,8 @@ export default function Home() {
               <PageTitle className="relative text-center sm:!max-w-none !w-full mx-auto">
                 <span className="relative z-10">Termos de Uso e</span>
                 <Image
-                  alt="CeZPEM"
+                  alt=""
+                  aria-hidden="true"
                   src="/details-text.png"
                   className="absolute z-0 m-auto w-full max-w-72 md:max-w-[400px] transform -translate-x-1/2 -translate-y-1/2 left-1/2 top-8 md:top-12"
                   width={484 * 2}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -50,6 +50,7 @@ export default function Footer() {
                       href="https://www.instagram.com/soberana.tv/"
                       className="md:hidden hover:opacity-80 inline-block absolute top-0 left-0"
                     >
+                      <span className="sr-only">Soberana.</span>
                       <SoberanaLogoText size="small" className="w-24" />
                     </a>
                   </span>
@@ -67,32 +68,38 @@ export default function Footer() {
           </div>
 
           <div className="flex flex-1 md:max-w-[50%] flex-col py-4 md:py-0">
+            <span className="sr-only">Confira nossas redes sociais:</span>
             {/* Ícones Sociais */}
             <div className="flex flex-col flex-wrap sm:flex-row w-24 sm:w-full items-center justify-center md:justify-between mx-auto gap-8 md:gap-16 md:mr-0">
               <SocialMediaLink
                 target="_blank"
                 href="https://www.instagram.com/centrozoiaprestes"
               >
-                <FaInstagram size={32} />
+                <span className="sr-only">Instagram</span>
+                <FaInstagram aria-hidden="true" size={32} />
               </SocialMediaLink>
               <SocialMediaLink
                 target="_blank"
                 href="https://discord.gg/hjZtJmCmVh"
               >
-                <FaDiscord size={32} />
+                <span className="sr-only">Discord</span>
+                <FaDiscord aria-hidden="true" size={32} />
               </SocialMediaLink>
               <SocialMediaLink
                 target="_blank"
                 href="https://www.youtube.com/@CeZPEM"
               >
-                <FaYoutube size={32} />
+                <span className="sr-only">Youtube</span>
+                <FaYoutube aria-hidden="true" size={32} />
               </SocialMediaLink>
               <SocialMediaLink
                 target="_blank"
                 href="https://soberana.tv"
                 className="hidden md:block hover:opacity-80 group mx-auto lg:mx-0"
               >
+                <span className="sr-only">Site do Coletivo Soberana</span>
                 <SoberanaLogoText
+                  aria-hidden="true"
                   size="small"
                   className="w-32 group-hover:scale-105 transition-transform duration-300 ease-in"
                 />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -21,6 +21,7 @@ export default function Header() {
                 className="flex mr-auto ml-0 items-center justify-center"
               >
                 <CezpemLogoText className="w-48 mr-auto" />
+                <span className="sr-only">Centro Zoia Prestes de Educação Multidisciplinar</span>
               </Link>
             </div>
 
@@ -34,7 +35,8 @@ export default function Header() {
               >
                 <Button className="w-full mt-4 md:mt-0">
                   <span className="flex flex-row w-full mx-auto text-center items-center gap-2">
-                    <IoMdStar
+                    <IoMdStar 
+                      aria-hidden="true"
                       className="group-hover:rotate-[216deg] transition-all duration-300 ease-in-out"
                       size={24}
                     />

--- a/src/components/Logos.tsx
+++ b/src/components/Logos.tsx
@@ -26,7 +26,8 @@ export function CezpemLogo({ className = "", size = "medium" }: LogoProps) {
     <div className={`flex items-center justify-center rounded ${className}`}>
       <Image
         src="/Logo-CeZPEM.svg"
-        alt="Logo do CeZPEM"
+        alt="" 
+        aria-hidden="true"
         width={width}
         height={height}
       />
@@ -46,7 +47,8 @@ export function CezpemText({
       <div className={`flex items-center justify-center rounded ${className}`}>
         <Image
           src="/logo-CeZPEM-branco.svg"
-          alt="Texto do CeZPEM"
+          alt="" 
+          aria-hidden="true"
           width={width}
           height={height}
         />
@@ -58,7 +60,8 @@ export function CezpemText({
     <div className={`flex items-center justify-center rounded ${className}`}>
       <Image
         src="/logo-CeZPEM-vermelho.svg"
-        alt="Texto do CeZPEM"
+        alt="" 
+        aria-hidden="true"
         width={width}
         height={height}
       />
@@ -99,7 +102,8 @@ export function LogoSoberana({ className = "", size = "medium" }: LogoProps) {
     <div className={`flex items-center justify-center rounded ${className}`}>
       <Image
         src="/Logo-Soberana.svg"
-        alt="Logo do Colégio Soberana"
+        alt="" 
+        aria-hidden="true"
         width={width}
         height={height}
       />
@@ -117,7 +121,8 @@ export function LogoSoberanaText({
     <div className={`flex items-center justify-center rounded ${className}`}>
       <Image
         src="/Texto-Soberana.svg"
-        alt="Texto do Colégio Soberana"
+        alt="" 
+        aria-hidden="true"
         width={width}
         height={height}
       />

--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -8,14 +8,16 @@ export default function MobileMenu() {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <>
+    <nav role="navigation" aria-label="Menu Principal">
       {/* Botão para abrir o Sidebar */}
       <button
-        name="Abrir menu"
+
         onClick={() => setIsOpen(true)}
+        aria-expanded={isOpen?"true":"false"}
         className="fixed right-5 top-4 lg:hidden z-[51] p-2 bg-white shadow-lg rounded-lg"
       >
-        <FiMenu size={28} />
+        <span className="sr-only">Abrir Menu</span>
+        <FiMenu aria-hidden="true" size={28} />
       </button>
 
       <Sidebar isOpen={isOpen} setIsOpen={setIsOpen} />
@@ -27,6 +29,6 @@ export default function MobileMenu() {
           className="fixed inset-0 bg-black/30 z-[52]"
         />
       )}
-    </>
+    </nav>
   );
 }

--- a/src/components/PageTitle.tsx
+++ b/src/components/PageTitle.tsx
@@ -1,12 +1,13 @@
 type PageTitleProps = {
   children: React.ReactNode;
+  text?: string;
   className?: string;
 };
 
-export function PageTitle({ children, className = "" }: PageTitleProps) {
+export function PageTitle({ children, text="text-black", className = "" }: PageTitleProps) {
   return (
     <h2
-      className={`leading-none text-32px md:text-40px font-bold text-black ${
+      className={`leading-none text-32px md:text-40px font-bold ${text} ${
         className ?? ""
       }`}
     >

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -19,6 +19,7 @@ export default function Sidebar({ isOpen, setIsOpen }: SidebarProps) {
 
   return (
     <aside
+      aria-hidden={isOpen?"false":"true"}
       className={`fixed top-0 left-0 h-full w-72 bg-white shadow transition-transform duration-300 z-[55] transform ${
         isOpen ? "translate-x-0" : "-translate-x-full"
       }`}
@@ -29,13 +30,14 @@ export default function Sidebar({ isOpen, setIsOpen }: SidebarProps) {
           <CezpemLogoText className="w-36" />
         </div>
         <button onClick={() => setIsOpen(false)} className="p-2 text-red-600">
-          <FiArrowLeft size={24} />
+          <span className="sr-only">Fechar Menu</span>
+          <FiArrowLeft aria-hidden="true" size={24} />
         </button>
       </div>
 
       {/* Menu de Navegação */}
       {isOpen && (
-        <nav>
+        
           <ul className="space-y-2 p-4">
             {menuItems.map((item) => {
               const newLink = item.href.replace("/", "") || "inicio";
@@ -69,7 +71,7 @@ export default function Sidebar({ isOpen, setIsOpen }: SidebarProps) {
               );
             })}
           </ul>
-        </nav>
+        
       )}
     </aside>
   );

--- a/src/components/Toggle.tsx
+++ b/src/components/Toggle.tsx
@@ -39,7 +39,8 @@ function Toggle({ title, children, onClick, open, className }: ToggleProps) {
         </Button>
 
         <span className="flex justify-start items-center h-8 min-w-3 pl-1">
-          <IoTriangleSharp
+          <IoTriangleSharp 
+            aria-hidden="true"
             size={14}
             className={`transition-all duration-300 ease-in-out ${
               isOpen ? "transform rotate-180" : "transform rotate-90"


### PR DESCRIPTION

https://github.com/user-attachments/assets/c42559b6-bd3d-44f4-a3b8-e7fe3245be86


https://github.com/user-attachments/assets/0bc1ef43-b752-4c2f-b14e-89ef351917c8

A experiência para usuários de leitores de tela não estava muito boa. Dei uma corrigida nisso e tenho alguns comentários: 

- Se a imagem é decorativa, então `alt=""`;
- Usamos `aria-hidden` quando queremos que o leitor de tela ignore certos componentes;
- O menu mobile não informava ao usuário se estava aberto ou fechado, isso foi corrigido;
- `span` tags com a classe `sr-only` são textos que só serão lidos por _screen readers_. É uma [classe nativa do tailwind](https://tailwindcss.com/docs/display#screen-reader-only). [Esse padrão também é conhecido como visually-hidden](https://www.a11yproject.com/posts/how-to-hide-content/);
- Pra evitar que o leitor de tela soletre CeZPEM toda vez que a palavra aparece, usei essa técnica:
```html
<span className="sr-only">cezpem</span> 
<abbr aria-hidden="true">CeZPEM</abbr>
```
- Mudei a cor do título "Apoie Nosso Projeto!" pra satisfazer requisitos de contraste;
- Seria excelente para acessibilidade se no futuro recriássemos o faq usando o [componente nativo do HTML para acordeão](https://www.w3schools.com/tags/tag_summary.asp).


Creio que os vídeos sejam suficientes pra ilustrar as melhorias (liguem o som). Agradeço demais a atenção, venceremos ❤